### PR TITLE
Fix/define models

### DIFF
--- a/src/models/album.ts
+++ b/src/models/album.ts
@@ -3,7 +3,7 @@ import Artist from './artist';
 import Song from './song';
 import AlbumArtist from './albumArtist';
 
-@Table({ tableName: 'album', freezeTableName: true })
+@Table({ tableName: 'album', freezeTableName: true, timestamps: false })
 export default class Album extends Model {
   @PrimaryKey
   @Column

--- a/src/models/album.ts
+++ b/src/models/album.ts
@@ -4,7 +4,7 @@ import Song from './song';
 import AlbumArtist from './albumArtist';
 
 @Table({ tableName: 'album', freezeTableName: true })
-export default class Album extends Model<Album> {
+export default class Album extends Model {
   @PrimaryKey
   @Column
   id: number;

--- a/src/models/albumArtist.ts
+++ b/src/models/albumArtist.ts
@@ -2,7 +2,7 @@ import { Table, Model, ForeignKey, Column } from 'sequelize-typescript';
 import Album from './album';
 import Artist from './artist';
 
-@Table({ tableName: 'album_artist', freezeTableName: true, underscored: true })
+@Table({ tableName: 'album_artist', freezeTableName: true, underscored: true, timestamps: false })
 export default class AlbumArtist extends Model {
   @ForeignKey(() => Album)
   @Column

--- a/src/models/albumArtist.ts
+++ b/src/models/albumArtist.ts
@@ -3,7 +3,7 @@ import Album from './album';
 import Artist from './artist';
 
 @Table({ tableName: 'album_artist', freezeTableName: true, underscored: true })
-export default class AlbumArtist extends Model<AlbumArtist> {
+export default class AlbumArtist extends Model {
   @ForeignKey(() => Album)
   @Column
   albumId: number;

--- a/src/models/artist.ts
+++ b/src/models/artist.ts
@@ -4,7 +4,7 @@ import AlbumArtist from './albumArtist';
 import Song from './song';
 import SongArtist from './songArtist';
 
-@Table({ tableName: 'artist', freezeTableName: true })
+@Table({ tableName: 'artist', freezeTableName: true, timestamps: false })
 export default class Artist extends Model {
   @PrimaryKey
   @Column

--- a/src/models/artist.ts
+++ b/src/models/artist.ts
@@ -5,7 +5,7 @@ import Song from './song';
 import SongArtist from './songArtist';
 
 @Table({ tableName: 'artist', freezeTableName: true })
-export default class Artist extends Model<Artist> {
+export default class Artist extends Model {
   @PrimaryKey
   @Column
   id: number;

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -22,7 +22,19 @@ const sequelize = new Sequelize({
   password: process.env.DB_PASSWORD,
 });
 
-sequelize.addModels([Album, AlbumArtist, Artist, KeyExpression, Mood, MySongs, MyVocab, Song, SongArtist, SongMood, User]);
+sequelize.addModels([
+  Album,
+  AlbumArtist,
+  Artist,
+  KeyExpression,
+  Mood,
+  MySongs,
+  MyVocab,
+  Song,
+  SongArtist,
+  SongMood,
+  User,
+]);
 
-export {Album, AlbumArtist, Artist, KeyExpression, Mood, MySongs, MyVocab, Song, SongArtist, SongMood, User};
+export { Album, AlbumArtist, Artist, KeyExpression, Mood, MySongs, MyVocab, Song, SongArtist, SongMood, User };
 export default sequelize;

--- a/src/models/keyExpression.ts
+++ b/src/models/keyExpression.ts
@@ -1,42 +1,33 @@
-import {
-    Model,
-    Column,
-    Table,
-    DataType,
-    ForeignKey,
-    BelongsTo,
-    BelongsToMany,
-    PrimaryKey
-} from 'sequelize-typescript';
+import { Model, Column, Table, DataType, ForeignKey, BelongsTo, BelongsToMany, PrimaryKey } from 'sequelize-typescript';
 import Song from './song';
 import MyVocab from './myVocab';
 import User from './user';
 
-@Table({ tableName: 'key_expression', freezeTableName: true, underscored: true})
-export default class KeyExpression extends Model<KeyExpression> {
-    @PrimaryKey
-    @Column
-    id: number;
+@Table({ tableName: 'key_expression', freezeTableName: true, underscored: true })
+export default class KeyExpression extends Model {
+  @PrimaryKey
+  @Column
+  id: number;
 
-    @Column(DataType.TEXT)
-    kor: string;
+  @Column(DataType.TEXT)
+  kor: string;
 
-    @Column(DataType.TEXT)
-    eng: string;
+  @Column(DataType.TEXT)
+  eng: string;
 
-    @Column(DataType.TEXT)
-    korExample: string;
+  @Column(DataType.TEXT)
+  korExample: string;
 
-    @Column(DataType.TEXT)
-    engExample: string;
+  @Column(DataType.TEXT)
+  engExample: string;
 
-    @ForeignKey(() => Song)
-    @Column
-    songId: number;
+  @ForeignKey(() => Song)
+  @Column
+  songId: number;
 
-    @BelongsTo(() => Song)
-    song: Song;
+  @BelongsTo(() => Song)
+  song: Song;
 
-    @BelongsToMany(() => User, () => MyVocab)
-    users: User[];
+  @BelongsToMany(() => User, () => MyVocab)
+  users: User[];
 }

--- a/src/models/keyExpression.ts
+++ b/src/models/keyExpression.ts
@@ -3,7 +3,7 @@ import Song from './song';
 import MyVocab from './myVocab';
 import User from './user';
 
-@Table({ tableName: 'key_expression', freezeTableName: true, underscored: true })
+@Table({ tableName: 'key_expression', freezeTableName: true, underscored: true, timestamps: false })
 export default class KeyExpression extends Model {
   @PrimaryKey
   @Column

--- a/src/models/mood.ts
+++ b/src/models/mood.ts
@@ -2,7 +2,7 @@ import { Model, Column, Table, DataType, Unique, BelongsToMany, PrimaryKey } fro
 import Song from './song';
 import SongMood from './songMood';
 
-@Table({ tableName: 'mood', freezeTableName: true, underscored: true })
+@Table({ tableName: 'mood', freezeTableName: true, underscored: true, timestamps: false })
 export default class Mood extends Model {
   @PrimaryKey
   @Column

--- a/src/models/mood.ts
+++ b/src/models/mood.ts
@@ -3,7 +3,7 @@ import Song from './song';
 import SongMood from './songMood';
 
 @Table({ tableName: 'mood', freezeTableName: true, underscored: true })
-export default class Mood extends Model<Mood> {
+export default class Mood extends Model {
   @PrimaryKey
   @Column
   id: number;

--- a/src/models/mySongs.ts
+++ b/src/models/mySongs.ts
@@ -3,7 +3,7 @@ import User from './user';
 import Song from './song';
 
 @Table({ tableName: 'my_songs', freezeTableName: true, underscored: true })
-export default class MySongs extends Model<MySongs> {
+export default class MySongs extends Model {
   @ForeignKey(() => User)
   @Column
   userId: number;

--- a/src/models/mySongs.ts
+++ b/src/models/mySongs.ts
@@ -1,8 +1,8 @@
-import { Column, ForeignKey, Table, Model } from 'sequelize-typescript';
+import { Column, ForeignKey, Table, Model, CreatedAt } from 'sequelize-typescript';
 import User from './user';
 import Song from './song';
 
-@Table({ tableName: 'my_songs', freezeTableName: true, underscored: true })
+@Table({ tableName: 'my_songs', freezeTableName: true, underscored: true, timestamps: false })
 export default class MySongs extends Model {
   @ForeignKey(() => User)
   @Column
@@ -11,4 +11,8 @@ export default class MySongs extends Model {
   @ForeignKey(() => Song)
   @Column
   songId: number;
+
+  @CreatedAt
+  @Column
+  createdAt?: Date;
 }

--- a/src/models/myVocab.ts
+++ b/src/models/myVocab.ts
@@ -3,7 +3,7 @@ import User from './user';
 import KeyExpression from './keyExpression';
 
 @Table({ tableName: 'my_vocab', freezeTableName: true, underscored: true })
-export default class MyVocab extends Model<MyVocab> {
+export default class MyVocab extends Model {
   @ForeignKey(() => User)
   @Column
   userId: number;

--- a/src/models/myVocab.ts
+++ b/src/models/myVocab.ts
@@ -1,8 +1,8 @@
-import { Column, ForeignKey, Table, Model } from 'sequelize-typescript';
+import { Column, ForeignKey, Table, Model, CreatedAt } from 'sequelize-typescript';
 import User from './user';
 import KeyExpression from './keyExpression';
 
-@Table({ tableName: 'my_vocab', freezeTableName: true, underscored: true })
+@Table({ tableName: 'my_vocab', freezeTableName: true, underscored: true, timestamps: false })
 export default class MyVocab extends Model {
   @ForeignKey(() => User)
   @Column
@@ -11,4 +11,8 @@ export default class MyVocab extends Model {
   @ForeignKey(() => KeyExpression)
   @Column
   keyExpressionId: number;
+
+  @CreatedAt
+  @Column
+  createdAt?: Date;
 }

--- a/src/models/song.ts
+++ b/src/models/song.ts
@@ -9,7 +9,7 @@ import {
   ForeignKey,
   BelongsTo,
   HasMany,
-  BelongsToMany
+  BelongsToMany,
 } from 'sequelize-typescript';
 import User from './user';
 import Album from './album';
@@ -21,7 +21,7 @@ import MySongs from './mySongs';
 import SongArtist from './songArtist';
 
 @Table({ tableName: 'song', freezeTableName: true, underscored: true })
-export default class Song extends Model<Song> {
+export default class Song extends Model {
   @PrimaryKey
   @Column
   id: number;

--- a/src/models/songArtist.ts
+++ b/src/models/songArtist.ts
@@ -2,7 +2,7 @@ import { Table, Model, ForeignKey, Column } from 'sequelize-typescript';
 import Song from './song';
 import Artist from './artist';
 
-@Table({ tableName: 'song_artist', freezeTableName: true, underscored: true })
+@Table({ tableName: 'song_artist', freezeTableName: true, underscored: true, timestamps: false })
 export default class SongArtist extends Model {
   @ForeignKey(() => Song)
   @Column

--- a/src/models/songArtist.ts
+++ b/src/models/songArtist.ts
@@ -3,7 +3,7 @@ import Song from './song';
 import Artist from './artist';
 
 @Table({ tableName: 'song_artist', freezeTableName: true, underscored: true })
-export default class SongArtist extends Model<SongArtist> {
+export default class SongArtist extends Model {
   @ForeignKey(() => Song)
   @Column
   songId: number;

--- a/src/models/songMood.ts
+++ b/src/models/songMood.ts
@@ -1,9 +1,9 @@
-import { Model, Column, Table, ForeignKey} from 'sequelize-typescript';
+import { Model, Column, Table, ForeignKey } from 'sequelize-typescript';
 import Song from './song';
 import Mood from './mood';
 
 @Table({ tableName: 'song_mood', freezeTableName: true, underscored: true })
-export default class SongMood extends Model<SongMood> {
+export default class SongMood extends Model {
   @ForeignKey(() => Song)
   @Column
   songId: number;

--- a/src/models/songMood.ts
+++ b/src/models/songMood.ts
@@ -2,7 +2,7 @@ import { Model, Column, Table, ForeignKey } from 'sequelize-typescript';
 import Song from './song';
 import Mood from './mood';
 
-@Table({ tableName: 'song_mood', freezeTableName: true, underscored: true })
+@Table({ tableName: 'song_mood', freezeTableName: true, underscored: true, timestamps: false })
 export default class SongMood extends Model {
   @ForeignKey(() => Song)
   @Column

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -15,7 +15,7 @@ import KeyExpression from './keyExpression';
 import MyVocab from './myVocab';
 
 @Table({ tableName: 'user', freezeTableName: true, underscored: true })
-export default class User extends Model<User> {
+export default class User extends Model {
   @PrimaryKey
   @Column
   id: number;


### PR DESCRIPTION
## 변경 사항 정리

- 개발 시에는 모델 변경 시 데이터베이스에 바로 반영되는 게 좋아서 sync 옵션을 true로 했었다. 근데 이제 바꿀일 없으면 다시 false로 하고 더미 넣으면 된다.
- 시퀄라이즈 버전 6에서는 model 정의 시 sequelize.Model을 상속받아야 함.
  Model<정의하려는모델> 상속받아서 생성하니까 create를 쓸 수 없었음..
- model들을 DB에 만들 때 테이블 timestamp 옵션이 default 가 true여서 쓸데없는 timestamp가 생겼었다. 옵션의 값을 false로 설정해서 timestamp가 생기지 않게 했어요.


## 테스트 됐나요?

- [x] 네!
- [ ] 아니요 (안 되는 걸 설명해주세요)

---

## 이 외에 할 말

사랑해..! 이제 거의 다왔당 >_<