### PR TITLE
Refact/repository: 리포지토리 계층 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,7 @@
 * [Coding Convention](https://github.com/Kyrics/kyrics-backend/blob/develop/CODINGCONVENTION.md)
 
 * [Contribution Guide](https://github.com/Kyrics/kyrics-backend/blob/develop/CONTRIBUTIONGUIDE.md)</b>
-<br>
 
-### 🌍 WorkFlow
-
-![workflow](https://kyrics.s3.ap-northeast-2.amazonaws.com/workflow.JPG)
-
-<br>
 
 ### ✔️ Main Feature
 
@@ -51,58 +45,17 @@
 
 <br>
 
-### :blue_book: Package
-
-```json
-  "dependencies": {
-    "@types/jsonwebtoken": "^8.5.4",
-    "cors": "^2.8.5",
-    "dotenv": "^10.0.0",
-    "express": "^4.17.1",
-    "jsonwebtoken": "^8.5.1",
-    "mysql2": "^2.2.5",
-    "pm2": "^5.1.0",
-    "reflect-metadata": "^0.1.13",
-    "sequelize": "^6.6.4",
-    "sequelize-cli": "^6.2.0",
-    "sequelize-typescript": "^2.1.0",
-    "swagger-cli": "^4.0.4",
-    "swagger-ui-express": "^4.1.6",
-    "ts-node": "^10.0.0",
-    "typescript": "^4.3.5",
-    "yamljs": "^0.3.0"
-  },
-  "devDependencies": {
-    "@types/cors": "^2.8.10",
-    "@types/express": "^4.17.12",
-    "@types/node": "^16.0.0",
-    "@types/sequelize": "^4.28.9",
-    "@types/swagger-ui-express": "^4.1.3",
-    "@types/validator": "^13.6.2",
-    "@types/yamljs": "^0.2.31",
-    "@typescript-eslint/eslint-plugin": "^4.28.1",
-    "@typescript-eslint/parser": "^4.28.1",
-    "eslint": "^7.30.0",
-    "eslint-config-airbnb-base": "^14.2.1",
-    "eslint-config-prettier": "^8.3.0",
-    "eslint-plugin-import": "^2.23.4",
-    "nodemon": "^2.0.9",
-    "prettier": "^2.3.2"
-  }
-```
-
-<br>
-
-### :green_book: Architecture
+### :green_book: Infrastructure
 
 ![architecture](https://github.com/Kyrics/kyrics-backend/blob/develop/img/server%20architecture.png?raw=true)  
 
 <br>
 
-### :closed_book: 배포
+### :closed_book: Cloud Service
 
 * AWS EC2 - 클라우드 컴퓨팅 시스템
-* AWS elastic beanstlak - 서버 배포및 관리 프로비저닝 서비스
+* AWS Elastic beanstlak - 서버 배포및 관리 프로비저닝 서비스
+* AWS RDS - 클라우드 관계형 데이터베이스
 * AWS S3 - 클라우드 데이터 저장소
 * AWS Route 53 - 클라우드 DNS 웹 서비스
 
@@ -111,10 +64,12 @@
 ### :books: 사용된 도구 
 
 * [Node.js](https://nodejs.org/ko/)
-* [Express.js](http://expressjs.com/ko/) 
-* [NPM](https://rometools.github.io/rome/) - 자바 스크립트 패키지 관리자
-* [PM2](http://pm2.keymetrics.io/) - 프로세스 관리자
-* [MySQL](https://www.mysql.com/) - RDBMS
+* [Express.js](http://expressjs.com/ko/)
+* [NPM](https://rometools.github.io/rome/) - 패키지 매니저
+* [PM2](http://pm2.keymetrics.io/)
+* [MySQL](https://www.mysql.com/)
+* [Sequelize-typescript](https://www.npmjs.com/package/sequelize-typescript) - 데이터베이스 ORM
+* [Swagger](https://swagger.io/) - API 명세
 
 <br>
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,14 +1,10 @@
 import express, { Request, Response, NextFunction } from 'express';
-import path from 'path';
-import YAML from 'yamljs';
-import swaggerUI from 'swagger-ui-express';
 import cors from 'cors';
 import sequelize from './models';
 import router from './router';
 import { PORT } from './common/env';
 
 const app = express();
-const swaggerSpec = YAML.load(path.join(__dirname, '../build/swagger.yaml'));
 
 app.use(cors());
 app.use((req: Request, res: Response, next: NextFunction) => {
@@ -21,13 +17,6 @@ app.use((req: Request, res: Response, next: NextFunction) => {
 app.use(express.urlencoded());
 app.use(express.json());
 
-app.use('/', router);
-app.use('/api-docs', swaggerUI.serve, swaggerUI.setup(swaggerSpec));
-app.use('/health-check', (req, res) => {
-  res.status(200).json({
-    message: 'Welcome to Kyrics API',
-  });
-});
 
 interface ExpressError extends Error {
   status: number;
@@ -38,6 +27,8 @@ app.use((err: ExpressError, req: Request, res: Response, next: NextFunction) => 
   res.locals.error = req.app.get('env') === 'production' ? err : {};
   res.status(err.status || 500);
 });
+
+app.use('/', router);
 
 sequelize.sync({ force: false });
 

--- a/src/controller/artist.ts
+++ b/src/controller/artist.ts
@@ -20,7 +20,7 @@ const getArtist = async (req: Request, res: Response) => {
   } catch (error) {
     return res.status(500).json({
       status: statusCode.INTERNAL_SERVER_ERROR,
-      message: '서버 내부 오류',
+      message: error.message,
     });
   }
 };

--- a/src/controller/artists.ts
+++ b/src/controller/artists.ts
@@ -3,19 +3,19 @@ import statusCode from '../module/statusCode';
 import { readArtists } from '../service/artists';
 
 const getArtists = async (req: Request, res: Response) => {
-    try {
-      const readArtistsRes = await readArtists();
-      return res.status(200).json({
-        status: statusCode.OK,
-        data: readArtistsRes,
-        message: '요청 성공',
-      });
-    } catch (error) {
-      return res.status(500).json({
-        status: statusCode.INTERNAL_SERVER_ERROR,
-        message: '서버 내부 오류',
-      });
-    }
+  try {
+    const readArtistsRes = await readArtists();
+    return res.status(200).json({
+      status: statusCode.OK,
+      data: readArtistsRes,
+      message: '요청 성공',
+    });
+  } catch (error) {
+    return res.status(500).json({
+      status: statusCode.INTERNAL_SERVER_ERROR,
+      message: error.message,
+    });
+  }
 };
 
 export { getArtists };

--- a/src/controller/logIn.ts
+++ b/src/controller/logIn.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express';
 import statusCode from '../module/statusCode';
-import { signupIfUserNotFoundAndLogin, socialLoginInput } from '../service/social';
+import { signupIfUserNotFoundOrLogin, userInfoDto } from '../service/social';
 
 const socialLogin = async (req: Request, res: Response) => {
   const { name, socialId, email, profileImageUrl, socialType } = req.body;
@@ -10,7 +10,7 @@ const socialLogin = async (req: Request, res: Response) => {
       message: '필요한 값이 없습니다.',
     });
   }
-  const input: socialLoginInput = {
+  const input: userInfoDto = {
     name,
     socialId,
     email,
@@ -18,7 +18,7 @@ const socialLogin = async (req: Request, res: Response) => {
     socialType,
   };
   try {
-    const { jwtSignRes: token, isNewUser } = await signupIfUserNotFoundAndLogin(input);
+    const { jwtSignRes: token, isNewUser } = await signupIfUserNotFoundOrLogin(input);
     return res.status(200).json({
       status: statusCode.OK,
       data: {
@@ -30,7 +30,7 @@ const socialLogin = async (req: Request, res: Response) => {
   } catch (error) {
     return res.json({
       status: statusCode.INTERNAL_SERVER_ERROR,
-      message: '서버 내부 오류',
+      message: error.message,
     });
   }
 };

--- a/src/controller/song.ts
+++ b/src/controller/song.ts
@@ -15,7 +15,7 @@ const getSong = async (req: Request, res: Response) => {
   } catch (error) {
     return res.status(500).json({
       status: statusCode.INTERNAL_SERVER_ERROR,
-      message: '서버 내부 오류',
+      message: error.message,
     });
   }
 };
@@ -39,7 +39,7 @@ const getVocabsInSong = async (req: Request, res: Response) => {
   } catch (error) {
     return res.status(500).json({
       status: statusCode.INTERNAL_SERVER_ERROR,
-      message: '서버 내부 오류',
+      message: error.message,
     });
   }
 };

--- a/src/controller/user.ts
+++ b/src/controller/user.ts
@@ -30,7 +30,7 @@ const getUser = async (req: Request, res: Response) => {
   } catch (error) {
     return res.status(500).json({
       status: statusCode.INTERNAL_SERVER_ERROR,
-      message: '서버 내부 오류',
+      message: error.message,
     });
   }
 };
@@ -52,7 +52,7 @@ const removeUser = async (req: Request, res: Response) => {
   } catch (error) {
     return res.status(500).json({
       status: statusCode.INTERNAL_SERVER_ERROR,
-      message: '서버 내부 오류',
+      message: error.message,
     });
   }
 };
@@ -81,7 +81,7 @@ const modifyUserEmail = async (req: Request, res: Response) => {
     }
     return res.status(500).json({
       status: statusCode.INTERNAL_SERVER_ERROR,
-      message: '서버 내부 오류',
+      message: error.message,
     });
   }
 };
@@ -104,7 +104,7 @@ const getMyVocabs = async (req: Request, res: Response) => {
   } catch (error) {
     return res.status(500).json({
       status: statusCode.INTERNAL_SERVER_ERROR,
-      message: '서버 내부 오류',
+      message: error.message,
     });
   }
 };
@@ -119,7 +119,7 @@ const postMySong = async (req: Request, res: Response) => {
     });
   }
   try {
-    await createMySong(+id, userId); // createMySong이 실패하면 에러를 던지게 한다.
+    await createMySong(+id, userId);
     return res.status(200).json({
       status: statusCode.OK,
       message: '요청 성공',
@@ -127,7 +127,7 @@ const postMySong = async (req: Request, res: Response) => {
   } catch (error) {
     return res.status(500).json({
       status: statusCode.INTERNAL_SERVER_ERROR,
-      message: '서버 내부 오류',
+      message: error.message,
     });
   }
 };
@@ -148,10 +148,9 @@ const removeMySong = async (req: Request, res: Response) => {
       message: '삭제 성공',
     });
   } catch (error) {
-    console.error(error);
     return res.status(500).json({
       status: statusCode.INTERNAL_SERVER_ERROR,
-      message: '서버 내부 에러',
+      message: error.message,
     });
   }
 };
@@ -174,7 +173,7 @@ const getMySongs = async (req: Request, res: Response) => {
   } catch (error) {
     return res.status(500).json({
       status: statusCode.INTERNAL_SERVER_ERROR,
-      message: '서버 내부 오류',
+      message: error.message,
     });
   }
 };
@@ -197,7 +196,7 @@ const postMyVocab = async (req: Request, res: Response) => {
   } catch (error) {
     return res.status(500).json({
       status: statusCode.INTERNAL_SERVER_ERROR,
-      message: '서버 내부 오류',
+      message: error.message,
     });
   }
 };
@@ -220,7 +219,7 @@ const removeMyVocab = async (req: Request, res: Response) => {
   } catch (error) {
     return res.status(500).json({
       status: statusCode.INTERNAL_SERVER_ERROR,
-      message: '서버 내부 에러',
+      message: error.message,
     });
   }
 };

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -5,7 +5,7 @@ import statusCode from '../module/statusCode';
 const TOKEN_EXPIRED = -3;
 const TOKEN_INVALID = -2;
 
-const decodeToken = async (req: Request, res: Response, next: NextFunction): Promise<any> => {
+const decodeToken = async (req: Request, res: Response, next: NextFunction) => {
   const token = req.headers['x-access-token'] as string;
   if (!token) {
     next();

--- a/src/module/seperator.ts
+++ b/src/module/seperator.ts
@@ -1,0 +1,20 @@
+const splitBySeperator = (korLyrics: string, engLyrics: string, lyricsStartTime: string, lyricsDuration: string) => {
+  const korLyricsList = korLyrics.split('/$');
+    const engLyricsList = engLyrics.split('/$');
+    const lyricsStartTimeList = lyricsStartTime.split('/$');
+    const lyricsDurationList = lyricsDuration.split('/$');
+
+    const lyricsObjAll = [];
+
+    for (let i = 0; i < korLyricsList.length; i += 1) {
+      lyricsObjAll.push({
+        startTime: +lyricsStartTimeList[i],
+        duration: +lyricsDurationList[i],
+        kor: korLyricsList[i],
+        eng: engLyricsList[i],
+      });
+    }
+    return lyricsObjAll;
+}
+
+export { splitBySeperator };

--- a/src/repository/artist.ts
+++ b/src/repository/artist.ts
@@ -1,0 +1,26 @@
+import { QueryTypes } from "sequelize";
+import sequelize from "../models";
+import Artist from '../models/artist'
+
+const findArtistById = async (id: number): Promise<Artist|null> => {
+  const findArtistByIdRes = await Artist.findByPk(id, {
+    attributes: ['id', 'name', ['background_image_url', 'backgroundImageUrl']],
+  });
+  return findArtistByIdRes;
+}
+
+
+const findSongWithAlbumCover = async (id: number) => {
+  const query = `SELECT song.id, title, album_image_url as albumImageUrl, artist.name as artist
+                FROM song
+                JOIN album ON(song.album_id=album.id)
+                JOIN song_artist ON(song.id=song_artist.song_id)
+                JOIN artist ON(artist.id=song_artist.artist_id)
+                WHERE artist.id=${id}
+                LIMIT 5;
+  `;
+  const findSongWithCover = await sequelize.query(query, { type: QueryTypes.SELECT });
+  return findSongWithCover;
+}
+
+export { findArtistById, findSongWithAlbumCover };

--- a/src/repository/artist.ts
+++ b/src/repository/artist.ts
@@ -1,14 +1,21 @@
-import { QueryTypes } from "sequelize";
-import sequelize from "../models";
-import Artist from '../models/artist'
+import { QueryTypes } from 'sequelize';
+import sequelize from '../models';
+import Artist from '../models/artist';
 
-const findArtistById = async (id: number): Promise<Artist|null> => {
+const findMainArtists = async (limit: number): Promise<Artist[]> => {
+  const findArtistsRes = await Artist.findAll({
+    attributes: ['id', 'name', 'profileImageUrl', 'logoImageUrl'],
+    limit,
+  });
+  return findArtistsRes;
+};
+
+const findArtistById = async (id: number): Promise<Artist> => {
   const findArtistByIdRes = await Artist.findByPk(id, {
     attributes: ['id', 'name', ['background_image_url', 'backgroundImageUrl']],
   });
   return findArtistByIdRes;
-}
-
+};
 
 const findSongWithAlbumCover = async (id: number) => {
   const query = `SELECT song.id, title, album_image_url as albumImageUrl, artist.name as artist
@@ -21,6 +28,6 @@ const findSongWithAlbumCover = async (id: number) => {
   `;
   const findSongWithCover = await sequelize.query(query, { type: QueryTypes.SELECT });
   return findSongWithCover;
-}
+};
 
-export { findArtistById, findSongWithAlbumCover };
+export { findMainArtists, findArtistById, findSongWithAlbumCover };

--- a/src/repository/keyExpression.ts
+++ b/src/repository/keyExpression.ts
@@ -1,0 +1,26 @@
+import { QueryTypes } from 'sequelize';
+import KeyExpression from '../models/keyExpression';
+import sequelize from '../models';
+import { IReadVocabsRes } from '../service/song';
+
+const findKeyExpressionBySongId = async (songId: number): Promise<KeyExpression[]> => {
+  const findAllKeyExpressionRes = await KeyExpression.findAll({
+    attributes: ['id', 'kor', 'eng', ['kor_example', 'korExample'], ['eng_example', 'engExample']],
+    where: { songId },
+  });
+  return findAllKeyExpressionRes;
+};
+
+const findKeyExpressionBySongIdWithLogin = async (songId: number, userId: number): Promise<IReadVocabsRes[]> => {
+  const vocabQuery = `SELECT id, kor, eng, kor_example as korExample, eng_example as engExample, key_expression_id as keyExpressionId
+                        FROM key_expression LEFT OUTER JOIN my_vocab
+                        ON (key_expression.id = my_vocab.key_expression_id
+                        AND my_vocab.user_id=${userId})
+                        WHERE key_expression.song_id=${songId};`;
+  const readVocab = (await sequelize.query<IReadVocabsRes>(vocabQuery, {
+    type: QueryTypes.SELECT,
+  })) as IReadVocabsRes[];
+  return readVocab;
+};
+
+export { findKeyExpressionBySongId, findKeyExpressionBySongIdWithLogin };

--- a/src/repository/mySongs.ts
+++ b/src/repository/mySongs.ts
@@ -1,0 +1,36 @@
+import { QueryTypes } from "sequelize";
+import MySongs from "../models/mySongs";
+import sequelize from "../models";
+import { IMySongsRes } from "../service/user";
+
+const readMySongsByUserId = async (userId: number) => {
+  const readMySongsQuery = `SELECT my_songs.song_id as id, song.title, artist.\`name\` as artist, album.album_image_url as albumImageUrl
+                            FROM my_songs
+                            LEFT OUTER JOIN song ON (my_songs.song_id = song.id)
+                            LEFT OUTER JOIN album ON (song.album_id = album.id)
+                            INNER JOIN song_artist ON (song.id = song_artist.song_id)
+                            INNER JOIN artist ON (song_artist.artist_id = artist.id)
+                            WHERE my_songs.user_id = ${userId}
+                            ORDER BY my_songs.created_at DESC;`;
+  const readMySongsRes = await sequelize.query(readMySongsQuery, { type: QueryTypes.SELECT }) as IMySongsRes[];
+  return readMySongsRes;
+}
+
+const createMySong = async (id: number, userId: number) => {
+  const createMySongsRes = await MySongs.create({
+    userId,
+    songId: id,
+  });
+  return createMySongsRes;
+}
+
+const destroyMySong = async (id: number, userId: number) => {
+  const destroyMySongsRes = await MySongs.destroy({
+    where: {
+      userId,
+      songId: id,
+    },
+  });
+  return destroyMySongsRes;
+}
+export { readMySongsByUserId, createMySong, destroyMySong }

--- a/src/repository/mySongs.ts
+++ b/src/repository/mySongs.ts
@@ -1,7 +1,7 @@
-import { QueryTypes } from "sequelize";
-import MySongs from "../models/mySongs";
-import sequelize from "../models";
-import { IMySongsRes } from "../service/user";
+import { QueryTypes } from 'sequelize';
+import MySongs from '../models/mySongs';
+import sequelize from '../models';
+import { IMySongsRes } from '../service/user';
 
 const readMySongsByUserId = async (userId: number) => {
   const readMySongsQuery = `SELECT my_songs.song_id as id, song.title, artist.\`name\` as artist, album.album_image_url as albumImageUrl
@@ -12,9 +12,9 @@ const readMySongsByUserId = async (userId: number) => {
                             INNER JOIN artist ON (song_artist.artist_id = artist.id)
                             WHERE my_songs.user_id = ${userId}
                             ORDER BY my_songs.created_at DESC;`;
-  const readMySongsRes = await sequelize.query(readMySongsQuery, { type: QueryTypes.SELECT }) as IMySongsRes[];
+  const readMySongsRes = (await sequelize.query(readMySongsQuery, { type: QueryTypes.SELECT })) as IMySongsRes[];
   return readMySongsRes;
-}
+};
 
 const createMySong = async (id: number, userId: number) => {
   const createMySongsRes = await MySongs.create({
@@ -22,7 +22,7 @@ const createMySong = async (id: number, userId: number) => {
     songId: id,
   });
   return createMySongsRes;
-}
+};
 
 const destroyMySong = async (id: number, userId: number) => {
   const destroyMySongsRes = await MySongs.destroy({
@@ -32,19 +32,19 @@ const destroyMySong = async (id: number, userId: number) => {
     },
   });
   return destroyMySongsRes;
-}
+};
 
-const isSongInUserSongs = async (songId: number, userId: number): Promise<Boolean | Error> => {
+const isSongInUserSongs = async (songId: number, userId: number): Promise<boolean | Error> => {
   try {
     const findMySongRes = await MySongs.findOne({
       where: {
         userId,
         songId,
-      }
+      },
     });
     return !!findMySongRes;
   } catch (error) {
     return new Error('isSaved 체크에 실패했습니다.');
   }
-}
-export { readMySongsByUserId, createMySong, destroyMySong, isSongInUserSongs }
+};
+export { readMySongsByUserId, createMySong, destroyMySong, isSongInUserSongs };

--- a/src/repository/mySongs.ts
+++ b/src/repository/mySongs.ts
@@ -33,4 +33,18 @@ const destroyMySong = async (id: number, userId: number) => {
   });
   return destroyMySongsRes;
 }
-export { readMySongsByUserId, createMySong, destroyMySong }
+
+const isSongInUserSongs = async (songId: number, userId: number): Promise<Boolean | Error> => {
+  try {
+    const findMySongRes = await MySongs.findOne({
+      where: {
+        userId,
+        songId,
+      }
+    });
+    return !!findMySongRes;
+  } catch (error) {
+    return new Error('isSaved 체크에 실패했습니다.');
+  }
+}
+export { readMySongsByUserId, createMySong, destroyMySong, isSongInUserSongs }

--- a/src/repository/myVocabs.ts
+++ b/src/repository/myVocabs.ts
@@ -1,0 +1,34 @@
+import { QueryTypes } from "sequelize";
+import MyVocab from '../models/myVocab';
+import sequelize from "../models";
+import { IMyVocabRes } from "../service/user";
+
+const readMyVocabByUserId = async (userId: number): Promise<IMyVocabRes[]|Error> => {
+  const readMyVocabQuery = `
+  SELECT my_vocab.key_expression_id as id, key_expression.kor, key_expression.eng, key_expression.kor_example as korExample, key_expression.eng_example as engExample
+  FROM my_vocab
+  LEFT OUTER JOIN key_expression ON (my_vocab.key_expression_id = key_expression.id)
+  WHERE my_vocab.user_id = ${userId}
+  ORDER BY my_vocab.created_at DESC;`;
+  const readMyVocabRes = await sequelize.query(readMyVocabQuery, { type: QueryTypes.SELECT }) as IMyVocabRes[];
+  return readMyVocabRes;
+}
+
+const createMyVocabByUserId = async (id: number, userId: number): Promise<MyVocab|Error> => {
+  const createMyVocabRes = await MyVocab.create({
+    userId,
+    keyExpressionId: id,
+  });
+  return createMyVocabRes;
+}
+
+const destroyMyVocab = async (id: number, userId: number): Promise<number|Error> => {
+  const destroyMyVocabRes = await MyVocab.destroy({
+    where: {
+      userId,
+      keyExpressionId: id,
+    },
+  });
+  return destroyMyVocabRes;
+}
+export { readMyVocabByUserId, createMyVocabByUserId, destroyMyVocab };

--- a/src/repository/myVocabs.ts
+++ b/src/repository/myVocabs.ts
@@ -1,28 +1,28 @@
-import { QueryTypes } from "sequelize";
+import { QueryTypes } from 'sequelize';
 import MyVocab from '../models/myVocab';
-import sequelize from "../models";
-import { IMyVocabRes } from "../service/user";
+import sequelize from '../models';
+import { IMyVocabRes } from '../service/user';
 
-const readMyVocabByUserId = async (userId: number): Promise<IMyVocabRes[]|Error> => {
+const readMyVocabByUserId = async (userId: number): Promise<IMyVocabRes[]> => {
   const readMyVocabQuery = `
   SELECT my_vocab.key_expression_id as id, key_expression.kor, key_expression.eng, key_expression.kor_example as korExample, key_expression.eng_example as engExample
   FROM my_vocab
   LEFT OUTER JOIN key_expression ON (my_vocab.key_expression_id = key_expression.id)
   WHERE my_vocab.user_id = ${userId}
   ORDER BY my_vocab.created_at DESC;`;
-  const readMyVocabRes = await sequelize.query(readMyVocabQuery, { type: QueryTypes.SELECT }) as IMyVocabRes[];
+  const readMyVocabRes = (await sequelize.query(readMyVocabQuery, { type: QueryTypes.SELECT })) as IMyVocabRes[];
   return readMyVocabRes;
-}
+};
 
-const createMyVocabByUserId = async (id: number, userId: number): Promise<MyVocab|Error> => {
+const createMyVocabByUserId = async (id: number, userId: number): Promise<MyVocab> => {
   const createMyVocabRes = await MyVocab.create({
     userId,
     keyExpressionId: id,
   });
   return createMyVocabRes;
-}
+};
 
-const destroyMyVocab = async (id: number, userId: number): Promise<number|Error> => {
+const destroyMyVocab = async (id: number, userId: number): Promise<number> => {
   const destroyMyVocabRes = await MyVocab.destroy({
     where: {
       userId,
@@ -30,5 +30,5 @@ const destroyMyVocab = async (id: number, userId: number): Promise<number|Error>
     },
   });
   return destroyMyVocabRes;
-}
+};
 export { readMyVocabByUserId, createMyVocabByUserId, destroyMyVocab };

--- a/src/repository/song.ts
+++ b/src/repository/song.ts
@@ -1,10 +1,12 @@
-
 import Song from '../models/song';
-import Artist from '../models/artist'
+import Artist from '../models/artist';
+import Album from '../models/album';
 
-const findSongById = async (id: number): Promise<Song> => {
-  const findSongByPkRes = await Song.findByPk(id);
+const findSongById = async (id: number) => {
+  const findSongByPkRes = await Song.findByPk(id, {
+    include: [Artist, Album],
+  });
   return findSongByPkRes;
-}
+};
 
 export { findSongById };

--- a/src/repository/song.ts
+++ b/src/repository/song.ts
@@ -1,0 +1,10 @@
+
+import Song from '../models/song';
+import Artist from '../models/artist'
+
+const findSongById = async (id: number): Promise<Song> => {
+  const findSongByPkRes = await Song.findByPk(id);
+  return findSongByPkRes;
+}
+
+export { findSongById };

--- a/src/repository/user.ts
+++ b/src/repository/user.ts
@@ -1,26 +1,49 @@
 import User from '../models/user';
+import { SocialType, userInfoDto } from '../service/social';
 
-const findUserById = async (id: number): Promise<User|null> => {
+const createUser = async (input: userInfoDto): Promise<User> => {
+  const { name, socialId, email, profileImageUrl, socialType } = input;
+  const createUserRes = await User.create({
+    name,
+    socialId,
+    email,
+    profileImageUrl,
+    socialType,
+  });
+  return createUserRes;
+};
+
+const findUserById = async (id: number): Promise<User> => {
   const readUserRes = await User.findOne({
     where: {
-      id
+      id,
     },
-    attributes: ['id', `name`, `email`, `profileImageUrl`]
-  })
+    attributes: ['id', `name`, `email`, `profileImageUrl`],
+  });
   return readUserRes;
-}
+};
+
+const findUserBySocialAccount = async (socialId: string, socialType: SocialType): Promise<User> => {
+  const userRes = await User.findOne({
+    where: {
+      socialId,
+      socialType,
+    },
+  });
+  return userRes;
+};
 
 const deleteUserById = async (id: number): Promise<number> => {
   const destroyUserRes = await User.destroy({
     where: {
-      id
-    }
+      id,
+    },
   });
   return destroyUserRes;
-}
+};
 
 const updateUser = async (user: User): Promise<User> => {
   return user.save();
-}
+};
 
-export { findUserById, deleteUserById, updateUser };
+export { createUser, findUserById, findUserBySocialAccount, deleteUserById, updateUser };

--- a/src/repository/user.ts
+++ b/src/repository/user.ts
@@ -1,0 +1,26 @@
+import User from '../models/user';
+
+const findUserById = async (id: number): Promise<User|null> => {
+  const readUserRes = await User.findOne({
+    where: {
+      id
+    },
+    attributes: ['id', `name`, `email`, `profileImageUrl`]
+  })
+  return readUserRes;
+}
+
+const deleteUserById = async (id: number): Promise<number> => {
+  const destroyUserRes = await User.destroy({
+    where: {
+      id
+    }
+  });
+  return destroyUserRes;
+}
+
+const updateUser = async (user: User): Promise<User> => {
+  return user.save();
+}
+
+export { findUserById, deleteUserById, updateUser };

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,4 +1,7 @@
 import express from 'express';
+import path from 'path';
+import YAML from 'yamljs';
+import swaggerUI from 'swagger-ui-express';
 import userRouter from './user';
 import songRouter from './song';
 import artistsRouter from './artists';
@@ -7,6 +10,21 @@ import { checkLogIn, decodeToken } from '../middleware/auth';
 import { getArtist } from '../controller/artist';
 
 const router = express.Router();
+
+router.use('/', (req, res) => {
+  res.status(200).json({
+    message: 'Welcome to Kyrics API',
+  });
+});
+
+router.use('/health-check', (req, res) => {
+  res.status(200).json({
+    message: 'health check: OK',
+  });
+})
+
+const swaggerSpec = YAML.load(path.join(__dirname, '../../build/swagger.yaml'));
+router.use('/api-docs', swaggerUI.serve, swaggerUI.setup(swaggerSpec));
 
 router.use('/login', socialLogin);
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -11,17 +11,11 @@ import { getArtist } from '../controller/artist';
 
 const router = express.Router();
 
-router.use('/', (req, res) => {
-  res.status(200).json({
-    message: 'Welcome to Kyrics API',
-  });
-});
-
 router.use('/health-check', (req, res) => {
   res.status(200).json({
     message: 'health check: OK',
   });
-})
+});
 
 const swaggerSpec = YAML.load(path.join(__dirname, '../../build/swagger.yaml'));
 router.use('/api-docs', swaggerUI.serve, swaggerUI.setup(swaggerSpec));

--- a/src/service/artist.ts
+++ b/src/service/artist.ts
@@ -1,6 +1,4 @@
-import { QueryTypes } from 'sequelize';
-import sequelize from '../models';
-import Artist from '../models/artist';
+import { findArtistById, findSongWithAlbumCover } from '../repository/artist'
 
 interface IReadArtistRes {
   id: number;
@@ -10,26 +8,17 @@ interface IReadArtistRes {
 }
 
 const readArtist = async (artistId: number): Promise<IReadArtistRes | Error> => {
-  const findArtistRes = await Artist.findByPk(artistId, {
-    attributes: ['id', 'name', ['background_image_url', 'backgroundImageUrl']],
-  });
+  const findArtistRes = await findArtistById(artistId);
   if (!findArtistRes) {
     throw Error('해당 id의 가수가 없습니다.');
   }
-  const query = `SELECT song.id, title, album_image_url as albumImageUrl, artist.name as artist
-                FROM song
-                JOIN album ON(song.album_id=album.id)
-                JOIN song_artist ON(song.id=song_artist.song_id)
-                JOIN artist ON(artist.id=song_artist.artist_id)
-                WHERE artist.id=${artistId}
-                LIMIT 5;
-  `;
-  const findSongWithAlbumCover = await sequelize.query(query, { type: QueryTypes.SELECT });
+
+  const findSongWithAlbumCoverRes = await findSongWithAlbumCover(artistId);
   return {
     id: artistId,
     artist: findArtistRes.name,
     backgroundImageUrl: findArtistRes.backgroundImageUrl,
-    songs: findSongWithAlbumCover,
+    songs: findSongWithAlbumCoverRes,
   };
 };
 

--- a/src/service/artist.ts
+++ b/src/service/artist.ts
@@ -1,4 +1,4 @@
-import { findArtistById, findSongWithAlbumCover } from '../repository/artist'
+import { findArtistById, findSongWithAlbumCover } from '../repository/artist';
 
 interface IReadArtistRes {
   id: number;

--- a/src/service/artists.ts
+++ b/src/service/artists.ts
@@ -1,11 +1,9 @@
 import Artist from '../models/artist';
+import { findMainArtists } from '../repository/artist';
 
-const readArtists = async (): Promise<Artist[] | Error> => {
-    const findArtistsRes = await Artist.findAll({
-        attributes: ['id', 'name', 'profileImageUrl', 'logoImageUrl'],
-        limit: 2
-    });
-    return findArtistsRes;
+const readArtists = async (): Promise<Artist[]> => {
+  const findMainArtistsRes = await findMainArtists(2);
+  return findMainArtistsRes;
 };
 
 export { readArtists };

--- a/src/service/artists.ts
+++ b/src/service/artists.ts
@@ -1,5 +1,3 @@
-import { QueryTypes } from 'sequelize';
-import sequelize from '../models';
 import Artist from '../models/artist';
 
 const readArtists = async (): Promise<Artist[] | Error> => {

--- a/src/service/user.ts
+++ b/src/service/user.ts
@@ -5,21 +5,21 @@ import { deleteUserById, findUserById, updateUser } from '../repository/user';
 import { readMySongsByUserId, createMySong as createMySongRepo, destroyMySong } from '../repository/mySongs';
 import { createMyVocabByUserId, destroyMyVocab, readMyVocabByUserId } from '../repository/myVocabs';
 
-interface IUserRes{
+interface IUserRes {
   id: number;
   name: string;
   email: string;
   profileImageUrl: string;
 }
 
-interface IMySongsRes{
+interface IMySongsRes {
   id: number;
-	title: string;
-	artists: string[];
-	albumImageUrl: string;
+  title: string;
+  artists: string[];
+  albumImageUrl: string;
 }
 
-interface IMyVocabRes{
+interface IMyVocabRes {
   id: number;
   kor: string;
   eng: string;
@@ -27,62 +27,87 @@ interface IMyVocabRes{
   EngExample: string;
 }
 
-const readUser = async(userId: number): Promise<IUserRes|Error> => {
+const readUser = async (userId: number): Promise<IUserRes> => {
   const readUserRes: IUserRes = await findUserById(userId);
   if (!readUserRes) {
-    return new Error('해당 id의 유저가 없습니다.');
+    throw new Error('해당 id의 유저가 없습니다.');
   }
   return readUserRes;
-}
+};
 
-const deleteUser = async (userId: number): Promise<number|Error> => {
+const deleteUser = async (userId: number): Promise<number> => {
   const destroyUserByIdRes = await deleteUserById(userId);
   if (!destroyUserByIdRes) {
-    return new Error('이미 존재하지 않는 유저입니다.');
+    throw new Error('이미 존재하지 않는 유저입니다.');
   }
   return destroyUserByIdRes;
 };
 
-const updateUserEmail = async (userId: number, newEmail: string): Promise<User|Error> => {
+const updateUserEmail = async (userId: number, newEmail: string): Promise<User> => {
   const findUserRes = await findUserById(userId);
   if (!findUserRes) {
-    return Error('유효하지 않은 아이디');
+    throw Error('유효하지 않은 아이디');
   }
   findUserRes.email = newEmail;
   const updateUserEmailRes = await updateUser(findUserRes);
   return updateUserEmailRes;
 };
 
-const readMySongs = async(userId: number): Promise<IMySongsRes[] | Error> => {
+const readMySongs = async (userId: number): Promise<IMySongsRes[]> => {
   return readMySongsByUserId(userId);
-}
-
-const createMySong = async (id: number, userId: number): Promise<MySongs | Error> => {
-  const createMySongRes = await createMySongRepo(id, userId);
-  return createMySongRes;
 };
 
-const deleteMySong = async (id: number, userId: number): Promise<number | Error> => {
+const createMySong = async (id: number, userId: number): Promise<MySongs> => {
+  try {
+    const createMySongRes = await createMySongRepo(id, userId);
+    return createMySongRes;
+  } catch (error) {
+    if (error.message === 'Validation error') throw new Error('이미 MySongs에 존재하는 노래입니다.');
+    throw error;
+  }
+};
+
+const deleteMySong = async (id: number, userId: number): Promise<number> => {
   const destroyMySongRes = await destroyMySong(id, userId);
-  if(!destroyMySong) {
-    return new Error('MySongs에 존재하지 않는 노래입니다.');
+  if (!destroyMySongRes) {
+    throw new Error('MySongs에 존재하지 않는 노래입니다.');
   }
   return destroyMySongRes;
 };
 
-const readMyVocab = async(userId: number): Promise<IMyVocabRes[] | Error> => {
-  return readMyVocabByUserId(userId);
-}
+const readMyVocab = async (userId: number): Promise<IMyVocabRes[]> => {
+  const readMyVocabRes = await readMyVocabByUserId(userId);
+  return readMyVocabRes;
+};
 
-const createMyVocab = async (id: number, userId: number): Promise<MyVocab | Error> => {
-    return createMyVocabByUserId(id, userId);
-  };
-  
-  const deleteMyVocab = async (id: number, userId: number): Promise<number | Error> => {
-    if (!deleteMyVocab) {
-      return new Error('myVocab에 존재하지 않는 vocab입니다.');
-    }
-    return destroyMyVocab(id, userId);
-  };
+const createMyVocab = async (id: number, userId: number): Promise<MyVocab> => {
+  try {
+    const createMyVocabRes = await createMyVocabByUserId(id, userId);
+    return createMyVocabRes;
+  } catch (error) {
+    if (error.message === 'Validation error') throw new Error('이미 MyVocab에 존재하는 단어입니다.');
+    throw error;
+  }
+};
 
-export { readUser, deleteUser, updateUserEmail, readMySongs, createMySong, deleteMySong, readMyVocab, createMyVocab, deleteMyVocab, IMySongsRes, IMyVocabRes };
+const deleteMyVocab = async (id: number, userId: number): Promise<number> => {
+  const deletedRowNum = await destroyMyVocab(id, userId);
+  if (!deletedRowNum) {
+    throw new Error('myVocab에 존재하지 않는 vocab입니다.');
+  }
+  return deletedRowNum;
+};
+
+export {
+  readUser,
+  deleteUser,
+  updateUserEmail,
+  readMySongs,
+  createMySong,
+  deleteMySong,
+  readMyVocab,
+  createMyVocab,
+  deleteMyVocab,
+  IMySongsRes,
+  IMyVocabRes,
+};


### PR DESCRIPTION
## 변경 사항 정리

- DB에 직접 접근하는 코드를 따로 분리했어요

- 라우팅하는 코드는 이제 `app.ts` 에서 전부 빼놨어요
- 각 엔티티에 대한 리포지토리를 만들었고
- 서비스 단에서시퀄라이즈를 직접 사용하는 코드는 지워주었어요 -> 이제 서비스에서는 리포지토리 함수 사용해야 DB 접근 가능
- 서버 에러 날 때 각 에러마다 메시지를 다르게 해주었어요. 
`err.message` -> caughted error의 메시지를 그대로 전달해주어요


## 부연설명 할게 있다면 여기에 적어주세요. (로직/생각의흐름)
모르는게 있다면 무조건 나한테 물어봐!!!!
수정된 이유가 궁금해도 물어보고 !!1 꼭 물어봐 주세요.
지금 여기에서 하나하나 설명하기가 힘들어!
꼭 코드 읽어보면서 이해하길 바라.

지금 깃에서 하나하나 보기에는 파일이 많으니까 일단 pull 받아서 보는게 편할거야!

한 api마다
라우트 -> 해당 컨트롤러 함수 -> 리포지토리 함수
이렇게 들어가보면서 보면 이해 될거야!

그리고 모르는 부분이 있으면 여기 지금 이 PR에다 모르는 부분에 코멘트 추가해줘!


## 테스트 됐나요?

- [x] 네!
- [ ] 아니요 (안 되는 걸 설명해주세요)

---

## 이 외에 할 말

하. 이제 Dto 분리해야함